### PR TITLE
Add hotkey action

### DIFF
--- a/index.js
+++ b/index.js
@@ -504,6 +504,18 @@ instance.prototype.actions = function() {
 					required: true
 				}
 			]
+		},
+		'trigger-hotkey': {
+			label: 'Trigger hotkey by ID',
+			tooltip: 'Find the hotkey ID in your profile settings file',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Hotkey ID',
+					id: 'id',
+					required: true
+				}
+			]
 		}
 	});
 };
@@ -588,6 +600,11 @@ instance.prototype.action = function(action) {
 			handle = self.obs.send('SetTextGDIPlusProperties', {
 				'source': action.options.source,
 				'text': action.options.text
+			})
+			break;
+		case 'trigger-hotkey':
+			handle = self.obs.send('TriggerHotkeyByName', {
+				'hotkeyName': action.options.id,
 			})
 			break;
 	}


### PR DESCRIPTION
Adds a button action to trigger a hotkey by its ID.  

The ID can be found by registering a keyboard shortcut, then browsing the `Hotkeys` section of your profile configuration file (i.e. `obs-studio/basic/profiles/Untitled/basic.ini`)
_Note: No actual keyboard shortcut actually needs to be assigned to the hotkey for it to be triggered_

---

This functionality does not rely on the version of [`obs-websocket-js`](https://github.com/haganbmj/obs-websocket-js), however it does rely on `obs-websocket` to have https://github.com/Palakis/obs-websocket/commit/0be5564ce7fa124f35d5a8efaec6749655ce4549 - which is not currently included in the latest binary release.