### PR TITLE
Make instance feedback reflect nested scenes

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,6 +267,7 @@ instance.prototype.updateScenesAndSources = async function() {
 	let sceneList = await self.obs.send('GetSceneList')
 	self.scenes = {};
 	self.states['scene_active'] = sceneList.currentScene;
+	self.setVariable('scene_active', sceneList.currentScene);
 	for (let scene of sceneList.scenes) {
 		self.scenes[scene.name] = scene;
 	}
@@ -306,6 +307,7 @@ instance.prototype.updateScenesAndSources = async function() {
 	self.init_feedbacks();
 	self.init_variables();
 	self.checkFeedbacks('scene_item_active');
+	self.checkFeedbacks('scene_active');
 };
 
 instance.prototype.updateInfo = function() {

--- a/index.js
+++ b/index.js
@@ -288,13 +288,13 @@ instance.prototype.updateScenesAndSources = async function() {
 	nestedVisibleScenes[sceneList.currentScene] = true
 
 	do {
-		lastNestedCount = nestedVisibleScenes.length
+		lastNestedCount = Object.keys(nestedVisibleScenes).length
 		for (let sceneName in nestedVisibleScenes) {
 			for (let nested of findNestedScenes(sceneName)) {
 				nestedVisibleScenes[nested] = true
 			}
 		}
-	} while (lastNestedCount != nestedVisibleScenes.length)
+	} while (lastNestedCount != Object.keys(nestedVisibleScenes).length)
 
 	for (let sceneName in nestedVisibleScenes) {
 		for (let source of self.scenes[sceneName].sources) {


### PR DESCRIPTION
Updates how scenes and sources are tracked to mark any source that is visible
on any scene that is embedded in any active scene.

Also adds all scenes to the sourcelist because all scenes can also be sources.

This fixes #21 