### PR TITLE
1.0.27: Add current media source variables, warnings about using newer, unsupported websocket versions

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -103,6 +103,9 @@ This module will allow you to control OBS Studio using the obs-websocket plugin.
 * transition_duration
 
 **Sources**
+* current_media_name *(Will only reflect one source if multiple media sources are playing)*
+* current_media_time_elapsed *(Will only reflect one source if multiple media sources are playing)*
+* current_media_time_remaining *(Will only reflect one source if multiple media sources are playing)*
 * media_status_*source_name* *(Current status of media sources, including: playing, paused, stopped, ended)*
 * media_file_name*source_name* *(Current file name of media sources, not including the extension)*
 * media_time_elapsed_*source_name*

--- a/index.js
+++ b/index.js
@@ -476,7 +476,7 @@ instance.prototype.getVersionInfo = async function () {
 				'warn',
 				'Update to the latest version of the OBS Websocket plugin to ensure full feature compatibility. A download link is available in the help menu for the OBS module.'
 			)
-		} else if (websocketVersion < 500) {
+		} else if (websocketVersion >= 500) {
 			self.log('error', 'Version 5.0.0 of OBS Websocket is not yet supported. Please use the 4.9.1 release.')
 		}
 	})

--- a/index.js
+++ b/index.js
@@ -985,10 +985,12 @@ instance.prototype.startMediaPoller = function () {
 	this.stopMediaPoller()
 	let self = this
 	this.mediaPoller = setInterval(() => {
+		let mediaSourcesPlaying = []
 		if (self.mediaSources) {
 			for (var s in self.mediaSources) {
 				let mediaSource = self.mediaSources[s]
 				if (self.mediaSources[mediaSource.sourceName]['mediaState'] === 'Playing') {
+					mediaSourcesPlaying.push(self.mediaSources[mediaSource.sourceName])
 					self.obs
 						.send('GetMediaTime', {
 							sourceName: mediaSource.sourceName,
@@ -1004,11 +1006,22 @@ instance.prototype.startMediaPoller = function () {
 								'media_time_remaining_' + mediaSource.sourceName,
 								'-' + new Date(timeRemaining).toISOString().slice(11, 19)
 							)
+							self.setVariable('current_media_time_elapsed', new Date(data.timestamp).toISOString().slice(11, 19))
+							self.setVariable(
+								'current_media_time_remaining',
+								'-' + new Date(timeRemaining).toISOString().slice(11, 19)
+							)
+							self.setVariable('current_media_name', mediaSource.sourceName)
 						})
 				} else if (self.mediaSources[mediaSource.sourceName]['mediaState'] === 'Stopped' || 'Ended') {
-					self.setVariable('media_time_elapsed_' + mediaSource.sourceName, '--:--:--')
-					self.setVariable('media_time_remaining_' + mediaSource.sourceName, '--:--:--')
+					self.setVariable('current_media_time_elapsed_' + mediaSource.sourceName, '--:--:--')
+					self.setVariable('current_media_time_remaining_' + mediaSource.sourceName, '--:--:--')
 				}
+			}
+			if (mediaSourcesPlaying.length == 0) {
+				self.setVariable('current_media_time_elapsed', '--:--:--')
+				self.setVariable('current_media_time_remaining', '--:--:--')
+				self.setVariable('current_media_name', 'None')
 			}
 		}
 	}, 1000)
@@ -3430,6 +3443,9 @@ instance.prototype.init_variables = function () {
 	variables.push({ name: 'scene_collection', label: 'Current scene collection' })
 	variables.push({ name: 'current_transition', label: 'Current transition' })
 	variables.push({ name: 'transition_duration', label: 'Current transition duration' })
+	variables.push({ name: 'current_media_name', label: 'Source name for currently playing media source' })
+	variables.push({ name: 'current_media_time_elapsed', label: 'Time elapsed for currently playing media source' })
+	variables.push({ name: 'current_media_time_remaining', label: 'Time remaining for currently playing media source' })
 
 	for (var s in self.mediaSources) {
 		let media = self.mediaSources[s]

--- a/index.js
+++ b/index.js
@@ -153,9 +153,11 @@ instance.prototype.init = function () {
 		})
 
 		self.obs.on('SceneCollectionChanged', function (data) {
-			self.states['current_scene_collection'] = data.sceneCollection
-			self.setVariable('scene_collection', data.sceneCollection)
-			self.checkFeedbacks('scene_collection_active')
+			//self.states['current_scene_collection'] = data.sceneCollection
+			//self.setVariable('scene_collection', data.sceneCollection)
+			//self.checkFeedbacks('scene_collection_active')
+			self.obs.disconnect()
+			self.log('warn', 'Briefly disconnecting from OBS while Scene Collection is changed')
 		})
 
 		self.obs.on('SceneCollectionListChanged', function () {

--- a/index.js
+++ b/index.js
@@ -476,6 +476,8 @@ instance.prototype.getVersionInfo = async function () {
 				'warn',
 				'Update to the latest version of the OBS Websocket plugin to ensure full feature compatibility. A download link is available in the help menu for the OBS module.'
 			)
+		} else if (websocketVersion < 500) {
+			self.log('error', 'Version 5.0.0 of OBS Websocket is not yet supported. Please use the 4.9.1 release.')
 		}
 	})
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obs-studio",
-	"version": "1.0.26",
+	"version": "1.0.27",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Stream"


### PR DESCRIPTION
Feat:
- Add current_media_name, time elapsed, time remaining variables

Minor:
- Warn users using version 5.0.0 version of OBS websocket it is not yet supported
- Try to disconnect on Scene Collection Change to prevent crash caused by OBS websocket