### PR TITLE
Feat: Media source remaining time feedback

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -83,6 +83,7 @@ This module will allow you to control OBS Studio using the obs-websocket plugin.
 - Audio Monitor Type
 - Volume
 - Media Playing
+- Media Source Remaining Time _(If remaining time of a media source is below a threshold, change the style of the button)_
 
 **General**
 

--- a/index.js
+++ b/index.js
@@ -865,7 +865,7 @@ instance.prototype.updateMediaSources = function () {
 		for (var s in data.mediaSources) {
 			let mediaSource = data.mediaSources[s]
 			if (!self.mediaSources[mediaSource.sourceName]) self.mediaSources[mediaSource.sourceName] = {}
-			self.mediaSources[mediaSource.sourceName] = Object.assign(self.mediaSources[mediaSource.sourceName], mediaSource);
+			self.mediaSources[mediaSource.sourceName] = Object.assign(self.mediaSources[mediaSource.sourceName], mediaSource)
 			self.mediaSources[mediaSource.sourceName]['mediaState'] =
 				mediaSource.mediaState.charAt(0).toUpperCase() + mediaSource.mediaState.slice(1)
 			if (self.mediaSources[mediaSource.sourceName]['mediaState'] === 'Opening') {
@@ -1118,7 +1118,7 @@ instance.prototype.destroy = function () {
 }
 
 // Returns true if a given scene name is in the active (on program) source, else false
-instance.prototype.isSourceOnProgram = function(sourceName) {
+instance.prototype.isSourceOnProgram = function (sourceName) {
 	var self = this
 	let scene = self.scenes[self.states['scene_active']]
 	if (scene && scene.sources) {
@@ -2961,8 +2961,8 @@ instance.prototype.init_feedbacks = function () {
 
 	feedbacks['media_source_time_remaining'] = {
 		type: 'boolean',
-		label: 'Media source remaining time',
-		description: 'Change colors when remaining time of a media source is below a threshold',
+		label: 'Media Source Remaining Time',
+		description: 'If remaining time of a media source is below a threshold, change the style of the button',
 		style: {
 			color: self.rgb(0, 0, 0),
 			bgcolor: self.rgb(255, 0, 0),
@@ -2972,9 +2972,9 @@ instance.prototype.init_feedbacks = function () {
 				type: 'dropdown',
 				label: 'Source name',
 				id: 'source',
-				default: self.sourcelistDefault,
-				choices: self.sourcelist,
-				minChoicesForSearch: 5
+				default: self.mediaSourceListDefault,
+				choices: self.mediaSourceList,
+				minChoicesForSearch: 5,
 			},
 			{
 				type: 'number',
@@ -2989,19 +2989,19 @@ instance.prototype.init_feedbacks = function () {
 				type: 'checkbox',
 				label: 'Feedback only if source is on program',
 				id: 'onlyIfSourceIsOnProgram',
-				default: false
+				default: false,
 			},
 			{
 				type: 'checkbox',
 				label: 'Feedback only if source is playing',
 				id: 'onlyIfSourceIsPlaying',
-				default: false
+				default: false,
 			},
 			{
 				type: 'checkbox',
 				label: 'Blinking',
 				id: 'blinkingEnabled',
-				default: false
+				default: false,
 			},
 		],
 	}
@@ -3208,7 +3208,13 @@ instance.prototype.feedback = function (feedback) {
 	}
 
 	if (feedback.type === 'media_source_time_remaining') {
-		const {source: sourceName, rtThreshold, onlyIfSourceIsOnProgram, onlyIfSourceIsPlaying, blinkingEnabled} = feedback.options;
+		const {
+			source: sourceName,
+			rtThreshold,
+			onlyIfSourceIsOnProgram,
+			onlyIfSourceIsPlaying,
+			blinkingEnabled,
+		} = feedback.options
 
 		let remainingTime // remaining time in seconds
 		let mediaState
@@ -3219,9 +3225,9 @@ instance.prototype.feedback = function (feedback) {
 		if (remainingTime === undefined) return false
 
 		if (onlyIfSourceIsOnProgram && !self.isSourceOnProgram(sourceName)) {
-			return false;
+			return false
 		}
-		
+
 		if (onlyIfSourceIsPlaying && mediaState !== 'Playing') {
 			return false
 		}
@@ -3229,7 +3235,8 @@ instance.prototype.feedback = function (feedback) {
 		if (remainingTime <= rtThreshold) {
 			if (blinkingEnabled && mediaState === 'Playing') {
 				// TODO: implement a better button blinking, or wait for https://github.com/bitfocus/companion/issues/674
-				if (remainingTime % 2 != 0) {  // flash in seconds interval (checkFeedbacks interval = media poller interval)
+				if (remainingTime % 2 != 0) {
+					// flash in seconds interval (checkFeedbacks interval = media poller interval)
 					return false
 				}
 			}

--- a/index.js
+++ b/index.js
@@ -3003,13 +3003,6 @@ instance.prototype.init_feedbacks = function () {
 				id: 'blinkingEnabled',
 				default: false
 			},
-			{
-				type: 'checkbox',
-				label: 'Debug',
-				id: 'debug',
-				default: false
-			},
-
 		],
 	}
 
@@ -3215,48 +3208,33 @@ instance.prototype.feedback = function (feedback) {
 	}
 
 	if (feedback.type === 'media_source_time_remaining') {
-		const sourceName = feedback.options.source
-		const rtThreshold = feedback.options.rtThreshold
-		const onlyIfSourceIsOnProgram = feedback.options.onlyIfSourceIsOnProgram
-		const onlyIfSourceIsPlaying = feedback.options.onlyIfSourceIsPlaying
-		const blinkingEnabled = feedback.options.blinkingEnabled
-
-		let debugLevel = 0
-		if (feedback.options.debug) debugLevel = 1
+		const {source: sourceName, rtThreshold, onlyIfSourceIsOnProgram, onlyIfSourceIsPlaying, blinkingEnabled} = feedback.options;
 
 		let remainingTime // remaining time in seconds
 		let mediaState
 		if (self.mediaSources && self.mediaSources[sourceName]) {
 			remainingTime = Math.round(self.mediaSources[sourceName].mediaTimeRemaining / 1000)
-			mediaState = self.mediaSources[sourceName].mediaState			
+			mediaState = self.mediaSources[sourceName].mediaState
 		}
 		if (remainingTime === undefined) return false
-		
-		if (debugLevel > 0) self.log('debug', 'media_source_time_remaining source: ' + sourceName + ', state: '  + mediaState + ', remaining time: ' + remainingTime + ' sec');
 
 		if (onlyIfSourceIsOnProgram && !self.isSourceOnProgram(sourceName)) {
-			if (debugLevel > 0) self.log('debug', 'media_source_time_remaining FEEDBACK OFF (not on program) [' + sourceName + ']');
 			return false;
 		}
 		
 		if (onlyIfSourceIsPlaying && mediaState !== 'Playing') {
-			if (debugLevel > 0) self.log('debug', 'media_source_time_remaining FEEDBACK OFF (not playing) [' + sourceName + ']');
 			return false
 		}
 
 		if (remainingTime <= rtThreshold) {
 			if (blinkingEnabled && mediaState === 'Playing') {
-				// TODO: implement a better button blinking
-				// or wait for https://github.com/bitfocus/companion/issues/674
+				// TODO: implement a better button blinking, or wait for https://github.com/bitfocus/companion/issues/674
 				if (remainingTime % 2 != 0) {  // flash in seconds interval (checkFeedbacks interval = media poller interval)
-					if (debugLevel > 0) self.log('debug', 'media_source_time_remaining FEEDBACK OFF (blink) [' + sourceName + ']');
 					return false
 				}
 			}
-			if (debugLevel > 0) self.log('debug', 'media_source_time_remaining FEEDBACK ON (remaining time below threshold) [' + sourceName + ']');
 			return true
 		}
-		if (debugLevel > 0) self.log('debug', 'media_source_time_remaining FEEDBACK OFF (remaining time above threshold) [' + sourceName + ']');
 	}
 
 	return false


### PR DESCRIPTION
This feature adds a "Media source remaining time feedback".

![Media_Source_Remaining_Time_Feedback_01](https://user-images.githubusercontent.com/99419948/155228233-bf9eab89-1fd7-4dcc-977e-d1c29c2d3583.png)

There is a debug switch included which probably should be removed before merging.

I've tested some use cases but probably not all edge cases.

When the blinking is switched off the feedback should be a constant feedback as long as the remaining time is below the threshold -> can be used with triggers (see also #144). If the blinking is enabled the boolean feedback toggles on and off.

Please let me know if such a feature would make sense for you. Any comments or change requests are welcome.