### PR TITLE
Fix grouped source visibility toggle, fix virtual camera control

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ See [HELP.md](https://github.com/bitfocus/companion-module-obs-studio/blob/maste
 
 ## Changelog
 
+### v2.0.4
+
+- Fix
+  - When using Set Scene Visibility on a group source, the sources within groups are now not affected
+  - Toggle/Start/Stop Output now works properly with Virtual Camera
+- Minor
+  - Update obs-websocket-js to latest version
+  - Use obs-websocket's Batch command for certain actions
+
 ### v2.0.3
 
 - Fix

--- a/index.js
+++ b/index.js
@@ -424,7 +424,6 @@ class instance extends instance_skel {
 			this.checkFeedbacks('replayBufferActive')
 		})
 		this.obs.on('VirtualcamStateChanged', (data) => {
-			this.debug('VIRTUAL' + data.outputActive)
 			this.outputs['virtualcam_output'].outputActive = data.outputActive
 			this.checkFeedbacks('output_active')
 		})

--- a/index.js
+++ b/index.js
@@ -830,7 +830,7 @@ class instance extends instance_skel {
 								sceneItemId: source.sceneItemId,
 								sceneItemEnabled: enabled,
 							})
-							if (source.isGroup) {
+							if (source.isGroup && sourceName === 'allSources') {
 								for (let x in this.groups[source.sourceName]) {
 									let item = this.groups[source.sourceName][x]
 									let groupEnabled

--- a/index.js
+++ b/index.js
@@ -424,6 +424,7 @@ class instance extends instance_skel {
 			this.checkFeedbacks('replayBufferActive')
 		})
 		this.obs.on('VirtualcamStateChanged', (data) => {
+			this.debug('VIRTUAL' + data.outputActive)
 			this.outputs['virtualcam_output'].outputActive = data.outputActive
 			this.checkFeedbacks('output_active')
 		})
@@ -852,21 +853,33 @@ class instance extends instance_skel {
 				break
 			//Outputs
 			case 'start_output':
-				requestType = 'StartOutput'
-				requestData = {
-					outputName: action.options.output,
+				if (action.options.output === 'virtualcam_output') {
+					requestType = 'StartVirtualCam'
+				} else {
+					requestType = 'StartOutput'
+					requestData = {
+						outputName: action.options.output,
+					}
 				}
 				break
 			case 'stop_output':
-				requestType = 'StopOutput'
-				requestData = {
-					outputName: action.options.output,
+				if (action.options.output === 'virtualcam_output') {
+					requestType = 'StopVirtualCam'
+				} else {
+					requestType = 'StopOutput'
+					requestData = {
+						outputName: action.options.output,
+					}
 				}
 				break
 			case 'start_stop_output':
-				requestType = 'ToggleOutput'
-				requestData = {
-					outputName: action.options.output,
+				if (action.options.output === 'virtualcam_output') {
+					requestType = 'ToggleVirtualCam'
+				} else {
+					requestType = 'ToggleOutput'
+					requestData = {
+						outputName: action.options.output,
+					}
 				}
 				break
 			case 'ToggleReplayBuffer':
@@ -1133,7 +1146,12 @@ class instance extends instance_skel {
 					let outputKind = output.outputKind
 					if (outputKind === 'virtualcam_output') {
 						this.outputList.push({ id: 'virtualcam_output', label: 'Virtual Camera' })
-					} else if (outputKind != 'ffmpeg_muxer' && outputKind != 'replay_buffer' && outputKind != 'rtmp_output') {
+					} else if (
+						outputKind != 'ffmpeg_muxer' &&
+						outputKind != 'ffmpeg_output' &&
+						outputKind != 'replay_buffer' &&
+						outputKind != 'rtmp_output'
+					) {
 						//The above outputKinds are handled separately by other actions, so they are omitted
 						this.outputList.push({ id: output.outputName, label: output.outputName })
 					}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obs-studio",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Stream"


### PR DESCRIPTION
Fix
  - When using Set Scene Visibility on a group source, the sources within groups are now not affected
  - Toggle/Start/Stop Output now works properly with Virtual Camera
Minor
  - Update obs-websocket-js to latest version
  - Use obs-websocket's Batch command for certain actions