### PR TITLE
check if media is a local file

### DIFF
--- a/variables.js
+++ b/variables.js
@@ -52,7 +52,7 @@ exports.updateVariableDefinitions = function () {
 		if (settings.playlist) {
 			file = settings.playlist[0].value.match(/[^\\\/]+(?=\.[\w]+$)|[^\\\/]+$/)
 			//Use first value in playlist until support for determining currently playing cue
-		} else {
+		} else if (settings.is_local_file) {
 			file = settings?.local_file.match(/[^\\\/]+(?=\.[\w]+$)|[^\\\/]+$/)
 		}
 		this.setVariable(`media_file_name_${mediaSourceName}`, file)


### PR DESCRIPTION
If source is a rtsp stream, his settings don't have "playlist" nor "local_file" properties.
It causes the code no crash but it stops there and the content of "variables" is not send to companion.