### PR TITLE
throw error if initial info is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,6 +253,10 @@ class OBSInstance extends InstanceBase {
 					this.buildSpecialInputs()
 					this.buildSceneList()
 				}
+				else {
+					//throw an error if initial info returns false.
+					throw new Error('could not get OBS info')
+				}
 			}
 		} catch (error) {
 			this.processWebsocketError(error)


### PR DESCRIPTION
If obsinfo returns false and handled the erro,r polling is not restarted. Therefor the error should be thrown.