### PR TITLE
feat: Fade Source Volume action, audio meter threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ See [HELP.md](https://github.com/bitfocus/companion-module-obs-studio/blob/maste
 ### v3.11.0
 
 - New
+  - Fade Source Volume action, allows fading a source's volume to a specific value over a specific duration
   - Ability to set a threshold in the Audio Meter feedback, so that sources with no signal or a high noise floor do not always show the green color feedback
 
 ### v3.10.1

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ See [HELP.md](https://github.com/bitfocus/companion-module-obs-studio/blob/maste
 
 ## Changelog
 
+### v3.11.0
+
+- New
+  - Ability to set a threshold in the Audio Meter feedback, so that sources with no signal or a high noise floor do not always show the green color feedback
+
 ### v3.10.1
 
 - Fix

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -817,7 +817,7 @@ export function getFeedbacks() {
 	feedbacks['audioMeter'] = {
 		type: 'advanced',
 		name: 'Audio Meter',
-		description: 'Change the style of the button to show audio meter colors similar to the OBS UI',
+		description: 'Change the style of the button to show colors based on peak values similar to the OBS UI audio meter',
 		options: [
 			{
 				type: 'dropdown',
@@ -826,15 +826,28 @@ export function getFeedbacks() {
 				default: this.audioSourceListDefault,
 				choices: this.audioSourceList,
 			},
+			{
+				type: 'number',
+				label: 'Threshold (dB)',
+				tooltip:
+					'Minimum value (between -100db and -21db) for the feedback to change to green. Color will default to black for values below this',
+				id: 'threshold',
+				default: -60,
+				max: -21,
+				min: -100,
+			},
 		],
 		callback: (feedback) => {
 			let peak = this.audioPeak?.[feedback.options.source]
+			const threshold = feedback.options.threshold ?? -60
 			if (peak > -9) {
 				return { bgcolor: ColorRed }
 			} else if (peak > -20) {
 				return { bgcolor: ColorOrange }
-			} else {
+			} else if (peak > threshold) {
 				return { bgcolor: ColorGreen }
+			} else {
+				return { bgcolor: ColorBlack }
 			}
 		},
 	}

--- a/upgrades.js
+++ b/upgrades.js
@@ -142,4 +142,22 @@ export default [
 
 		return changes
 	},
+	function v3_11_0(context, props) {
+		let changes = {
+			updatedConfig: null,
+			updatedActions: [],
+			updatedFeedbacks: [],
+		}
+
+		for (const feedback of props.feedbacks) {
+			if (feedback.feedbackId === 'audioMeter') {
+				if (!feedback.options.threshold) {
+					feedback.options.threshold = -60
+				}
+				changes.updatedFeedbacks.push(feedback)
+			}
+		}
+
+		return changes
+	},
 ]


### PR DESCRIPTION
- Fade Source Volume action, allows fading a source's volume to a specific value over a specific duration (closes https://github.com/bitfocus/companion-module-obs-studio/issues/299)
- Ability to set a threshold in the Audio Meter feedback, so that sources with no signal or a high noise floor do not always show the green color feedback (closes https://github.com/bitfocus/companion-module-obs-studio/issues/303)