### PR TITLE
Adding server scheme option for ws / wss

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,17 @@ class OBSInstance extends InstanceBase {
 				label: 'Server Password',
 				width: 4,
 			},
+			{
+				type: 'dropdown',
+				id: 'scheme',
+				label: 'Server Scheme',
+				default: 'ws',
+				choices: [
+					{ id: 'ws', label: 'ws' },
+					{ id: 'wss', label: 'wss' },
+				],
+				width: 4,
+			},
 		]
 	}
 
@@ -234,7 +245,7 @@ class OBSInstance extends InstanceBase {
 		}
 		try {
 			const { obsWebSocketVersion } = await this.obs.connect(
-				`ws://${this.config.host}:${this.config.port}`,
+				`${this.config.scheme ?? 'ws'}://${this.config.host}:${this.config.port}`,
 				this.config.pass,
 				{
 					eventSubscriptions:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obs-studio",
-	"version": "3.15.4",
+	"version": "3.16.0",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obs-studio",
-	"version": "3.15.3",
+	"version": "3.15.4",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {

--- a/upgrades.js
+++ b/upgrades.js
@@ -203,4 +203,13 @@ export default [
 		}
 		return changes
 	},
+	function v3_16_0(context, props) {
+		let changes = {
+			updatedConfig: { ...props.config, scheme: 'ws' },
+			updatedActions: [],
+			updatedFeedbacks: [],
+		}
+
+		return changes
+	},
 ]


### PR DESCRIPTION
There are a few services that exist to "proxy" OBS through a local browser source, and sometimes SSL is used meaning we need to support `wss://`. *(A browser source is used to connect out to a websocket, then connect to OBS over 127.0.0.1 and proxy the messages bi-directionally, however this same feature will benefit SSL users who proxy directly to OBS through something like cloudflared)*

For example in my use-case my product IRLRelayr.com has a free service that lets you access your local OBS websocket from anywhere without opening ports to your local machine with a URL similar to the following
`wss://78180302207321319.remote.irlrelayr.com` or through a dashboard that allows easy control of your instance.

Now that we can select a scheme, stuff like this will work without custom local changes, it currently defaults to `ws`, I've updated version to 3.16.0, a minor change instead of a patch, since every change with upgrades seems to be minor versions which does make sense, whilst this does work when the scheme is not set in the config, this improves UX after changing configuration variables to show the new default of `ws`.