### PR TITLE
feat: Set or toggle audio output tracks

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1091,7 +1091,7 @@ export function getActions() {
 				type: 'multidropdown',
 				label: 'Tracks',
 				id: 'tracks',
-				default: '1',
+				default: ['1'],
 				isVisible: (options) => options.all === false,
 				choices: [
 					{ id: '1', label: 'Track 1' },

--- a/actions.js
+++ b/actions.js
@@ -1070,6 +1070,74 @@ export function getActions() {
 			}
 		},
 	}
+	actions.toggle_output_tracks = {
+		name: 'Toggle Audio Output Tracks',
+		description: 'Toggle the output track(s) of an audio source',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Source',
+				id: 'source',
+				default: this.audioSourceListDefault,
+				choices: this.audioSourceList,
+			},
+			{
+				type: 'checkbox',
+				label: 'All Tracks',
+				id: 'all',
+				default: false,
+			},
+			{
+				type: 'multidropdown',
+				label: 'Tracks',
+				id: 'tracks',
+				default: '1',
+				isVisible: (options) => options.all === false,
+				choices: [
+					{ id: '1', label: 'Track 1' },
+					{ id: '2', label: 'Track 2' },
+					{ id: '3', label: 'Track 3' },
+					{ id: '4', label: 'Track 4' },
+					{ id: '5', label: 'Track 5' },
+					{ id: '6', label: 'Track 6' },
+				],
+			},
+			{
+				type: 'dropdown',
+				label: 'Output',
+				id: 'output',
+				default: 'toggle',
+				choices: [
+					{ id: 'toggle', label: 'Toggle' },
+					{ id: 'true', label: 'True' },
+					{ id: 'false', label: 'False' },
+				],
+			},
+		],
+		callback: async (action) => {
+			let sourceName = await this.parseVariablesInString(action.options.source);
+			let audioTrackIDs = await this.parseVariablesInString(action.options.tracks);
+			let sourceAudioTracks = this.sources[sourceName]?.inputAudioTracks;
+			let setAudioTracks = {};
+			if (sourceAudioTracks) {
+				Object.entries(sourceAudioTracks).forEach(([trackNo, enabled]) => {
+				    if(action.options.all === true || action.options.tracks.includes(trackNo)) {
+					if(action.options.output === 'toggle') {
+						setAudioTracks[trackNo] = !enabled;
+					} else {
+						setAudioTracks[trackNo] = action.options.output == 'true' ? true : false;
+					}
+				    }
+				});
+				await this.sendRequest('SetInputAudioTracks', {
+					inputName: action.options.source,
+					inputAudioTracks: setAudioTracks
+				})
+			} else {
+				return
+			}
+		},
+	},
 	actions['toggle_scene_item'] = {
 		name: 'Set Source Visibility',
 		description: 'Set or toggle the visibility of a source within a scene',

--- a/actions.js
+++ b/actions.js
@@ -971,6 +971,105 @@ export function getActions() {
 			})
 		},
 	}
+	actions['set_output_tracks'] = {
+		name: 'Set Audio Output Tracks',
+		description: 'Set or toggle the output tracks of an audio source',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Source',
+				id: 'source',
+				default: this.audioSourceListDefault,
+				choices: this.audioSourceList,
+			},
+			{
+				type: 'dropdown',
+				label: 'Track 1',
+				id: 'track1',
+				default: 'true',
+				choices: [
+					{ id: 'toggle', label: 'Toggle' },
+					{ id: 'true', label: 'True' },
+					{ id: 'false', label: 'False' },
+				],
+			},
+			{
+				type: 'dropdown',
+				label: 'Track 2',
+				id: 'track2',
+				default: 'true',
+				choices: [
+					{ id: 'toggle', label: 'Toggle' },
+					{ id: 'true', label: 'True' },
+					{ id: 'false', label: 'False' },
+				],
+			},
+			{
+				type: 'dropdown',
+				label: 'Track 3',
+				id: 'track3',
+				default: 'true',
+				choices: [
+					{ id: 'toggle', label: 'Toggle' },
+					{ id: 'true', label: 'True' },
+					{ id: 'false', label: 'False' },
+				],
+			},
+			{
+				type: 'dropdown',
+				label: 'Track 4',
+				id: 'track4',
+				default: 'true',
+				choices: [
+					{ id: 'toggle', label: 'Toggle' },
+					{ id: 'true', label: 'True' },
+					{ id: 'false', label: 'False' },
+				],
+			},
+			{
+				type: 'dropdown',
+				label: 'Track 5',
+				id: 'track5',
+				default: 'true',
+				choices: [
+					{ id: 'toggle', label: 'Toggle' },
+					{ id: 'true', label: 'True' },
+					{ id: 'false', label: 'False' },
+				],
+			},
+			{
+				type: 'dropdown',
+				label: 'Track 6',
+				id: 'track6',
+				default: 'true',
+				choices: [
+					{ id: 'toggle', label: 'Toggle' },
+					{ id: 'true', label: 'True' },
+					{ id: 'false', label: 'False' },
+				],
+			},
+		],
+		callback: async (action) => {
+			let sourceName = await this.parseVariablesInString(action.options.source)
+			let sourceAudioTracks = this.sources[sourceName]?.inputAudioTracks;
+			let setAudioTracks = {};
+			if (sourceAudioTracks) {
+				Object.entries(sourceAudioTracks).forEach(([trackNo, enabled]) => {
+				    if(action.options['track'+trackNo] === 'toggle') {
+					setAudioTracks[trackNo] = !enabled;
+				    } else {
+					setAudioTracks[trackNo] = action.options['track'+trackNo] == 'true' ? true : false;
+				    }
+				})
+				await this.sendRequest('SetInputAudioTracks', {
+					inputName: action.options.source,
+					inputAudioTracks: setAudioTracks
+				})
+			} else {
+				return
+			}
+		},
+	}
 	actions['toggle_scene_item'] = {
 		name: 'Set Source Visibility',
 		description: 'Set or toggle the visibility of a source within a scene',

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -44,7 +44,7 @@ This module will allow you to control OBS Studio using the built-in WebSocket Se
 - Set Audio Monitor
 - Set Audio Sync Offset
 - Set Audio Balance
-- Set Audio Tracks
+- Source Audio Tracks (Set Per-Track / Toggle Selected / Toggle All)
 - Set Source Text
 - Set Text Properties
 - Refresh Browser Source

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -44,6 +44,7 @@ This module will allow you to control OBS Studio using the built-in WebSocket Se
 - Set Audio Monitor
 - Set Audio Sync Offset
 - Set Audio Balance
+- Set Audio Tracks
 - Set Source Text
 - Set Text Properties
 - Refresh Browser Source

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -158,6 +158,7 @@ This module will allow you to control OBS Studio using the built-in WebSocket Se
 - monitor (Current audio monitoring state of a source)
 - sync_offset (Current audio sync offset of a source)
 - balance (Current audio balance of a source)
+- tracks (Current audio output tracks of a source)
 
 **General**
 

--- a/index.js
+++ b/index.js
@@ -480,7 +480,11 @@ class OBSInstance extends InstanceBase {
 				[`sync_offset_${name}`]: this.sources[data.inputName].inputAudioSyncOffset + 'ms',
 			})
 		})
-		this.obs.on('InputAudioTracksChanged', () => {})
+		this.obs.on('InputAudioTracksChanged', (data) => {
+			this.sources[data.inputName].inputAudioTracks = data.inputAudioTracks
+			let name = this.sources[data.inputName].validName
+			this.setVariableValues({ [`tracks_${name}`]: this.sources[data.inputName].inputAudioTracks })
+		})
 		this.obs.on('InputAudioMonitorTypeChanged', (data) => {
 			this.sources[data.inputName].monitorType = data.monitorType
 			let name = this.sources[data.inputName].validName
@@ -1582,6 +1586,7 @@ class OBSInstance extends InstanceBase {
 					}
 					case 'GetInputAudioTracks':
 						this.sources[sourceName].inputAudioTracks = data.inputAudioTracks
+						this.setVariableValues({ [`tracks_${validName}`]: this.sources[sourceName].inputAudioTracks })
 						break
 					default:
 						break
@@ -1594,6 +1599,7 @@ class OBSInstance extends InstanceBase {
 			[`volume_${validName}`]: this.sources[sourceName].inputVolume + 'dB',
 			[`balance_${validName}`]: this.sources[sourceName].inputAudioBalance,
 			[`sync_offset_${validName}`]: this.sources[sourceName].inputAudioSyncOffset + 'ms',
+			[`tracks_${validName}`]: this.sources[sourceName].inputAudioTracks,
 		})
 		this.checkFeedbacks('audio_muted', 'volume', 'audio_monitor_type')
 	}

--- a/variables.js
+++ b/variables.js
@@ -109,6 +109,7 @@ export function getVariables() {
 				{ variableId: `monitor_${sourceName}`, name: `${sourceName} - Audio monitor` },
 				{ variableId: `sync_offset_${sourceName}`, name: `${sourceName} - Sync offset` },
 				{ variableId: `balance_${sourceName}`, name: `${sourceName} - Audio balance` },
+				{ variableId: `tracks_${sourceName}`, name: `${sourceName} - Tracks` },
 			)
 		}
 	}
@@ -202,6 +203,7 @@ export function updateVariableValues() {
 				[`sync_offset_${sourceName}`]:
 					source.inputAudioSyncOffset !== undefined ? source.inputAudioSyncOffset + 'ms' : '',
 				[`balance_${sourceName}`]: source.inputAudioBalance !== undefined ? source.inputAudioBalance : '',
+				[`tracks_${sourceName}`]: source.inputAudioTracks !== undefined ? source.inputAudioTracks : {},
 			})
 		}
 	}


### PR DESCRIPTION
Added actions for managing the output tracks of audio sources.
1. Select source and individually set (true/false) or toggle each track
<img width="904" height="388" alt="image" src="https://github.com/user-attachments/assets/f14c8c44-3815-4abd-bd56-105522885b3c" />

2. Select source and set (true/false) or toggle the state  of selected (or all) tracks
<img width="905" height="258" alt="image" src="https://github.com/user-attachments/assets/53258207-7af8-4ad8-98d7-244aa8a994c4" />

---
Additionally exposed each audio source track object as variable.

**Use case**
When utilizing the Twitch VOD track or the [MultiRTMP](https://github.com/sorayuki/obs-multi-rtmp) plugin with a non-default output track selected or having multiple audio tracks set up in the recording settings; if a source is still needed on the main audio track, but not the VOD track or vice versa, this can now be managed here instead of the Advanced Volume Properties without needing to mute the source.

This gives the user more control over where to _route_ the audio.