### PR TITLE
Fix feedback for Smart Scene Switcher presets

### DIFF
--- a/presets.js
+++ b/presets.js
@@ -110,9 +110,10 @@ export function getPresets() {
 			],
 			feedbacks: [
 				{
-					feedbackId: 'programAndPreview',
+					feedbackId: 'scene_active',
 					options: {
 						scene: scene.id,
+						mode: 'programAndPreview',
 						fg: ColorWhite,
 						bg: ColorGreen,
 						fg_preview: ColorWhite,


### PR DESCRIPTION
Used the wrong feedback/mode for the new preset buttons so buttons would be created with invalid feedback set.